### PR TITLE
Do not use async for storing user requests

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -33,7 +33,7 @@ const createAndApplyActions = async () => {
       res.send('LIMIT');
     }
 
-    await storage.saveData(sender, address);
+    storage.saveData(sender, address);
     
     const hash = await actions.sendDOTs(address, amount);
     res.send(hash);


### PR DESCRIPTION
- Prevents slow matrix replies allowing users to go over daily quota in requests.