### PR TITLE
Fix daily limits, set to 20hr rolling window

### DIFF
--- a/src/server/storage.js
+++ b/src/server/storage.js
@@ -2,8 +2,9 @@ const Datastore = require('nedb');
 const crypto = require('crypto');
 
 const SECOND  = 1000;
-const HOUR    = 60 * SECOND;
-const DAY     = 24 * HOUR;
+const MINUTE  = 60 * SECOND; 
+const HOUR    = 60 * MINUTE;
+const DAY     = 20 * HOUR; // almost 1 day, give some room for people missing their normal daily slots
 
 const CompactionTimeout = 10 * SECOND;
 


### PR DESCRIPTION
Closes #5 

So I normally request at say 7am, if I request tomorrow at 9am, I would like my normal 7am slot back the day after. So just less of a pain when not exactly 24hrs